### PR TITLE
hotfix-validDate

### DIFF
--- a/delimitedData.py
+++ b/delimitedData.py
@@ -47,10 +47,13 @@ class DelimitedData:
         nowYear = int(date.today().year)
         nowMonth = int(date.today().month)
 
+        checkMonth = nowMonth-monthInit
+        if(checkMonth < 0):
+            nowYear -= 1
+            checkMonth += 12
+
         if(year == nowYear):
-            print(year, month, nowYear, nowMonth)
-            if(month >= nowMonth-monthInit):
-                print(year, month, nowYear, nowMonth)
+            if(month >= checkMonth):
                 return True
             else:
                 return False


### PR DESCRIPTION
La consulta hasta ahora se realizaba solo bajo el año en curso, con esta modificación, si dentro del rango de consulta deben haber datos del año pasado, los asume y los anexa como debe ser, por ejemplo; estando en el mes de abril, si hago una consulta de hace 6 meses usando el método "semester", obviamente deben haber datos del año pasado.